### PR TITLE
fix: sync send window cron on startup

### DIFF
--- a/DouYinSparkFlow/webui/app.py
+++ b/DouYinSparkFlow/webui/app.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import traceback
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import urllib.error
@@ -47,6 +48,7 @@ from webui.ops import (
     restart_proxy,
     run_task_now,
     run_unsent_retry_now,
+    sync_daily_schedule_from_config,
     update_daily_schedule,
 )
 
@@ -196,7 +198,16 @@ def save_exported_login_result(login_result: dict, *, relogin_unique_id: str = "
 
 def create_app():
     settings = get_app_settings()
-    app = FastAPI(title="DouYin Spark Flow Admin")
+
+    @asynccontextmanager
+    async def lifespan(_app):
+        """Synchronize configured startup state during the Web UI lifespan."""
+        result = sync_daily_schedule_from_config()
+        if getattr(result, "returncode", 1) != 0:
+            logger.warning("schedule startup sync failed: %s", getattr(result, "stderr", ""))
+        yield
+
+    app = FastAPI(title="DouYin Spark Flow Admin", lifespan=lifespan)
     app.add_middleware(
         SessionMiddleware,
         secret_key=settings["session_secret"],

--- a/DouYinSparkFlow/webui/ops.py
+++ b/DouYinSparkFlow/webui/ops.py
@@ -420,6 +420,27 @@ def update_daily_schedule(time_string):
         return _empty_result(stderr=str(exc))
 
 
+def sync_daily_schedule_from_config():
+    """Ensure the enabled send window config is materialized into the mounted cron file."""
+    window = dict(get_config(force_reload=True).get("dailySendWindow") or {})
+    if not window.get("enabled"):
+        return subprocess.CompletedProcess(args=["sync-daily-schedule"], returncode=0, stdout="disabled", stderr="")
+    if not running_in_container() or not HOST_CRONTAB_PATH.parent.exists():
+        return subprocess.CompletedProcess(args=["sync-daily-schedule"], returncode=0, stdout="skipped", stderr="")
+
+    try:
+        time_string = _format_window_schedule(window)
+        current = HOST_CRONTAB_PATH.read_text(encoding="utf-8", errors="replace") if HOST_CRONTAB_PATH.exists() else ""
+        updated = replace_douyin_cron_schedule(current, time_string)
+        if current == updated:
+            return subprocess.CompletedProcess(args=["sync-daily-schedule"], returncode=0, stdout="unchanged", stderr="")
+        HOST_CRONTAB_PATH.write_text(updated, encoding="utf-8")
+        return subprocess.CompletedProcess(args=["sync-daily-schedule"], returncode=0, stdout="synced", stderr="")
+    except Exception as exc:
+        logger.error("sync_daily_schedule_from_config failed: %s", exc)
+        return _empty_result(stderr=str(exc))
+
+
 def current_daily_schedule():
     config = get_config(force_reload=True)
     window = dict(config.get("dailySendWindow") or {})

--- a/DouYinSparkFlow/webui/ops.py
+++ b/DouYinSparkFlow/webui/ops.py
@@ -485,6 +485,7 @@ def _account_identity(user):
 
 
 def _scheduled_send_time(user, target_name, send_window, now):
+    """Return the deterministic planned send time for a target on the current day."""
     window_minutes = max(1, (send_window["endHour"] - send_window["startHour"]) * 60)
     start_of_window = now.replace(
         hour=send_window["startHour"],
@@ -496,6 +497,21 @@ def _scheduled_send_time(user, target_name, send_window, now):
     digest = hashlib.sha256(seed.encode("utf-8")).digest()
     offset_minutes = int.from_bytes(digest[:8], "big") % window_minutes
     return start_of_window + timedelta(minutes=offset_minutes)
+
+
+def _window_fallback_deadline(send_window, now):
+    """Return the last automatic retry check time for the current send window."""
+    return now.replace(
+        hour=send_window["endHour"],
+        minute=0,
+        second=0,
+        microsecond=0,
+    ) + timedelta(minutes=send_window["scheduleIntervalMinutes"])
+
+
+def _window_has_finished_for_today(send_window, now):
+    """Return True when both the configured window and fallback check have passed."""
+    return bool(send_window.get("enabled")) and now > _window_fallback_deadline(send_window, now)
 
 
 def _build_target_status(account, target_name, now, send_window):
@@ -515,6 +531,7 @@ def _build_target_status(account, target_name, now, send_window):
             "reason": "",
             "attemptCount": 0,
             "scheduledAt": "",
+            "scheduleNote": "",
         }
 
     failure_entry = failure_queue.get(target_name) or {}
@@ -530,9 +547,11 @@ def _build_target_status(account, target_name, now, send_window):
             "reason": str(failure_entry.get("reason") or ""),
             "attemptCount": int(failure_entry.get("attemptCount") or 0),
             "scheduledAt": "",
+            "scheduleNote": "",
         }
 
     scheduled_at = None
+    schedule_note = ""
     if send_window.get("enabled"):
         scheduled_at = _scheduled_send_time(account, target_name, send_window, now)
         if scheduled_at > now:
@@ -546,7 +565,10 @@ def _build_target_status(account, target_name, now, send_window):
                 "reason": "",
                 "attemptCount": 0,
                 "scheduledAt": scheduled_at.isoformat(timespec="seconds"),
+                "scheduleNote": "",
             }
+        if _window_has_finished_for_today(send_window, now):
+            schedule_note = "今天窗口已结束，明天自动发送或请手动补发"
 
     return {
         "target": target_name,
@@ -558,6 +580,7 @@ def _build_target_status(account, target_name, now, send_window):
         "reason": "",
         "attemptCount": 0,
         "scheduledAt": scheduled_at.isoformat(timespec="seconds") if scheduled_at else "",
+        "scheduleNote": schedule_note,
     }
 
 

--- a/DouYinSparkFlow/webui/templates/send_console.html
+++ b/DouYinSparkFlow/webui/templates/send_console.html
@@ -374,14 +374,14 @@
               <thead>
                 <tr>
                   <th>目标</th>
-                  <th>scheduledAt</th>
+                  <th>计划/提示</th>
                 </tr>
               </thead>
               <tbody>
                 {% for item in account.unprocessed_targets[:5] %}
                 <tr>
                   <td>{{ item.target }}</td>
-                  <td>{{ item.scheduledAt or "-" }}</td>
+                  <td>{{ item.scheduleNote or item.scheduledAt or "-" }}</td>
                 </tr>
                 {% else %}
                 <tr>
@@ -409,14 +409,14 @@
                 <thead>
                   <tr>
                     <th>目标</th>
-                    <th>scheduledAt</th>
+                    <th>计划/提示</th>
                   </tr>
                 </thead>
                 <tbody>
                   {% for item in account.unprocessed_targets %}
                   <tr>
                     <td>{{ item.target }}</td>
-                    <td>{{ item.scheduledAt or "-" }}</td>
+                    <td>{{ item.scheduleNote or item.scheduledAt or "-" }}</td>
                   </tr>
                   {% endfor %}
                 </tbody>


### PR DESCRIPTION
## Bug 原因

### 1. 启动后 cron 未从已有发送窗口配置初始化

发送窗口配置保存在 `config.json` 的 `dailySendWindow` 中，前端会直接读取该配置展示窗口状态。

但实际定时任务依赖 `state/cron/root` 中的 cron 内容，只有用户重新保存发送窗口时，`update_daily_schedule()` 才会把配置写入 cron 文件。

因此在项目刚启动、`state/cron` 目录为空时，会出现前端显示已配置发送窗口，但 `scheduler` 实际没有任何定时任务可执行的问题。

### 2. 窗口结束后新增好友仍会被 hash 到当天已过期时间段

例如发送窗口配置为 `10:00-18:00`，如果用户在 `19:00` 添加好友，该好友仍会根据 hash 计算出当天 `10:00-18:00` 内的计划发送时间。

由于当天窗口已经结束，这个计划时间实际不会再触发自动发送，但前端原先只展示计划时间，缺少明确提示，用户无法判断为什么没有自动发送。

## 修复方案

- 新增 `sync_daily_schedule_from_config()`，在容器环境且 `/host-spool-cron` 挂载存在时，将已启用的 `dailySendWindow` 幂等同步到 cron 文件。
- 在 Web UI 启动生命周期中调用同步逻辑，确保已有配置会在启动时自动落地到 `state/cron/root`。
- 使用 FastAPI `lifespan` 实现启动同步，避免使用已弃用的 `@app.on_event("startup")`。
- 为发送窗口已结束的未处理目标增加 `scheduleNote`，前端优先展示“今天窗口已结束，明天自动发送或请手动补发”。

## 验证

- `python3 -m py_compile DouYinSparkFlow/webui/app.py DouYinSparkFlow/webui/ops.py`
- `docker compose exec -T web python -m py_compile /app/webui/app.py /app/webui/ops.py`
- `docker compose exec -T web python -c "import webui.app; print('app import ok')"`
- `docker compose exec -T web python -c "from webui.ops import sync_daily_schedule_from_config; result = sync_daily_schedule_from_config(); print(result.returncode, result.stdout, result.stderr)"`
